### PR TITLE
Panic and performance fixes

### DIFF
--- a/src/bin/sonogram/main.rs
+++ b/src/bin/sonogram/main.rs
@@ -204,13 +204,10 @@ fn main() {
         let height = 250;
         let legend = gradient.to_legend(width, height);
 
-        let mut img: Vec<u8> = vec![0u8; width * height * 4];
-        for (i, color) in legend.iter().take(width * height).enumerate() {
-            img[i * 4] = color.r;
-            img[i * 4 + 1] = color.g;
-            img[i * 4 + 2] = color.b;
-            img[i * 4 + 3] = color.a;
-        }
+        let img = legend
+            .iter()
+            .flat_map(|colour| [colour.r, colour.g, colour.b, colour.a].into_iter())
+            .collect::<Vec<u8>>();
 
         let file = File::create(&args.legend.unwrap()).unwrap();
         let buf = &mut BufWriter::new(file);

--- a/src/bin/sonogram/main.rs
+++ b/src/bin/sonogram/main.rs
@@ -205,12 +205,11 @@ fn main() {
         let legend = gradient.to_legend(width, height);
 
         let mut img: Vec<u8> = vec![0u8; width * height * 4];
-        for (i, col) in legend.iter().take(width * height).enumerate() {
-            let colour = col.to_vec();
-            img[i * 4] = colour[0];
-            img[i * 4 + 1] = colour[1];
-            img[i * 4 + 2] = colour[2];
-            img[i * 4 + 3] = colour[3];
+        for (i, color) in legend.iter().take(width * height).enumerate() {
+            img[i * 4] = color.r;
+            img[i * 4 + 1] = color.g;
+            img[i * 4 + 2] = color.b;
+            img[i * 4 + 3] = color.a;
         }
 
         let file = File::create(&args.legend.unwrap()).unwrap();

--- a/src/colour_gradient.rs
+++ b/src/colour_gradient.rs
@@ -27,19 +27,15 @@ pub enum ColourTheme {
 /// Colours required for a PNG file, includes the alpha channel.
 #[derive(Clone, PartialEq, Debug)]
 pub struct RGBAColour {
-    r: u8,
-    g: u8,
-    b: u8,
-    a: u8,
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+    pub a: u8,
 }
 
 impl RGBAColour {
     pub fn new(r: u8, g: u8, b: u8, a: u8) -> Self {
         Self { r, g, b, a }
-    }
-
-    pub fn to_vec(&self) -> Vec<u8> {
-        vec![self.r, self.g, self.b, self.a]
     }
 }
 

--- a/src/colour_gradient.rs
+++ b/src/colour_gradient.rs
@@ -138,6 +138,11 @@ impl ColourGradient {
         let ratio = scaled_value - idx_value as f32;
         let (i, j) = (idx_value, idx_value + 1);
 
+        // Prevent over indexing after index computation
+        if j >= self.colours.len() {
+            return self.colours.last().unwrap().clone();
+        }
+
         // Get the colour band
         let first = self.colours[i].clone();
         let second = self.colours[j].clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,11 +123,11 @@ impl Spectrogram {
         gradient.set_max(max);
 
         for (i, val) in buf.iter().enumerate() {
-            let colour = gradient.get_colour(*val).to_vec();
-            img[i * 4] = colour[0];
-            img[i * 4 + 1] = colour[1];
-            img[i * 4 + 2] = colour[2];
-            img[i * 4 + 3] = colour[3];
+            let colour = gradient.get_colour(*val);
+            img[i * 4] = colour.r;
+            img[i * 4 + 1] = colour.g;
+            img[i * 4 + 2] = colour.b;
+            img[i * 4 + 3] = colour.a;
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,31 @@ impl Spectrogram {
         Ok(pngbuf)
     }
 
+    ///
+    /// Create the spectrogram in memory as raw RGBA format.
+    ///
+    /// # Arguments
+    ///
+    ///  * `freq_scale` - The type of frequency scale to use for the spectrogram.
+    ///  * `gradient` - The colour gradient to use for the spectrogram.
+    ///  * `w_img` - The output image width.
+    ///  * `h_img` - The output image height.
+    ///
+    pub fn to_rgba_in_memory(
+        &mut self,
+        freq_scale: FrequencyScale,
+        gradient: &mut ColourGradient,
+        w_img: usize,
+        h_img: usize,
+    ) -> Vec<u8> {
+        let buf = self.to_buffer(freq_scale, w_img, h_img);
+
+        let mut img: Vec<u8> = vec![0u8; w_img * h_img * 4];
+        self.buf_to_img(&buf, &mut img, gradient);
+
+        img
+    }
+
     /// Convenience function to convert the the buffer to an image
     fn buf_to_img(&self, buf: &[f32], img: &mut [u8], gradient: &mut ColourGradient) {
         let (min, max) = get_min_max(buf);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,13 +147,13 @@ impl Spectrogram {
         gradient.set_min(min);
         gradient.set_max(max);
 
-        for (i, val) in buf.iter().enumerate() {
-            let colour = gradient.get_colour(*val);
-            img[i * 4] = colour.r;
-            img[i * 4 + 1] = colour.g;
-            img[i * 4 + 2] = colour.b;
-            img[i * 4 + 3] = colour.a;
-        }
+        // For each pixel, compute the RGBAColour, then assign each byte to output img
+        buf
+            .iter()
+            .map(|val| gradient.get_colour(*val))
+            .flat_map(|c| [c.r, c.g, c.b, c.a].into_iter())
+            .zip(img.iter_mut())
+            .for_each(|(val_rgba, img_rgba)| *img_rgba = val_rgba);
     }
 
     ///


### PR DESCRIPTION
While I was using the crate to produce images on 1666Hz data in real-time (rather than CLI call pattern), I noticed a crash due to colour indexing arithmetic as well as extra allocations. 

After performance changes, there is only one allocation of the inplace buffer and the scratch buffer and the output spec is iterated with steps of `width` instead of index computation. Also, the`RGBAColour::to_vec` function is removed because it was used to produce an unnecessary allocation per pixel.

The Blackman Harris window function dominated the compute call run time.
<img width="1155" alt="Screen Shot 2022-04-05 at 11 14 21 AM" src="https://user-images.githubusercontent.com/8592049/161811211-0fbf73c5-9a68-4389-9255-449c8c76f576.png">

The Rectangular window function doesn't show up at all.
<img width="1035" alt="Screen Shot 2022-04-05 at 11 41 00 AM" src="https://user-images.githubusercontent.com/8592049/161812909-27697c2c-21ed-4047-a653-8b2392efab88.png">



