### PR TITLE
Fix to_csv that had incorrect number of columns

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ impl Spectrogram {
         let mut writer = csv::Writer::from_path(fname)?;
 
         // Create the CSV header
-        let mut csv_record: Vec<String> = (0..cols * rows)
+        let mut csv_record: Vec<String> = (0..cols)
             .into_iter()
             .map(|x| x.to_string())
             .collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,10 +177,7 @@ impl Spectrogram {
         let mut writer = csv::Writer::from_path(fname)?;
 
         // Create the CSV header
-        let mut csv_record: Vec<String> = (0..cols)
-            .into_iter()
-            .map(|x| x.to_string())
-            .collect();
+        let mut csv_record: Vec<String> = (0..cols).into_iter().map(|x| x.to_string()).collect();
         writer.write_record(&csv_record)?;
 
         let mut i = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ impl Spectrogram {
     ///  * `img_width` - The output image width.
     ///  * `img_height` - The output image height.
     ///
-    fn to_buffer(
+    pub fn to_buffer(
         &self,
         freq_scale: FrequencyScale,
         img_width: usize,


### PR DESCRIPTION
to_csv was creating a whole extra number of columns. 
The number of columns should be "cols"  wide not "cols * rows"