### PR TITLE
Make clap, hound, and png crates optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,18 @@ repository = "https://github.com/psiphi75/sonogram"
 keywords = ["spectrogram", "spectrograph", "audio", "fft", "dft"]
 categories = ["multimedia::images", "science", "multimedia::audio", "visualization"]
 
+[features]
+default = [ "hound", "png" ]
+build-binary = ["clap"]
+
+[[bin]]
+name = "sonogram"
+required-features = ["build-binary"]
 
 [dependencies]
-hound = "3.4"
-clap = { version = "3.0.14", features = ["derive"] }
-png = "0.14"
+hound = { version = "3.4", optional = true }
+clap = { version = "3.0.14", features = ["derive"], optional = true }
+png = { version = "0.14", optional = true }
 csv = "1.1"
 rustfft = "6.0"
 resize = "0.7.2"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -16,6 +16,7 @@
  */
 
 use std::f32;
+#[cfg(feature = "png")]
 use std::path::Path;
 
 use crate::errors::SonogramError;
@@ -83,6 +84,7 @@ impl SpecOptionsBuilder {
     ///
     ///  * `fname` - The path to the file.
     ///
+    #[cfg(feature = "hound")]
     pub fn load_data_from_file(self, fname: &Path) -> Result<Self, SonogramError> {
         let mut reader = hound::WavReader::open(fname)?;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,7 @@ use std::io;
 #[derive(Debug)]
 pub enum SonogramError {
     Io(io::Error),
+    #[cfg(feature = "hound")]
     Hound(hound::Error),
 
     // Our own errors
@@ -19,6 +20,7 @@ impl From<io::Error> for SonogramError {
     }
 }
 
+#[cfg(feature = "hound")]
 impl From<hound::Error> for SonogramError {
     fn from(err: hound::Error) -> SonogramError {
         SonogramError::Hound(err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
  */
 
 extern crate csv;
+#[cfg(feature = "png")]
 extern crate png;
 
 mod builder;
@@ -32,7 +33,9 @@ pub use freq_scales::{FreqScaler, FrequencyScale};
 pub use spec_core::SpecCompute;
 pub use window_fn::*;
 
+#[cfg(feature = "png")]
 use std::fs::File;
+#[cfg(feature = "png")]
 use std::io::BufWriter;
 use std::path::Path;
 
@@ -40,6 +43,7 @@ use resize::Pixel::GrayF32;
 use resize::Type::Lanczos3;
 use rgb::FromSlice;
 
+#[cfg(feature = "png")]
 use png::HasParameters; // To use encoder.set()
 
 pub struct Spectrogram {
@@ -60,6 +64,7 @@ impl Spectrogram {
     ///  * `w_img` - The output image width.
     ///  * `h_img` - The output image height.
     ///
+    #[cfg(feature = "png")]
     pub fn to_png(
         &mut self,
         fname: &Path,
@@ -93,6 +98,7 @@ impl Spectrogram {
     ///  * `w_img` - The output image width.
     ///  * `h_img` - The output image height.
     ///
+    #[cfg(feature = "png")]
     pub fn to_png_in_memory(
         &mut self,
         freq_scale: FrequencyScale,


### PR DESCRIPTION
This improves compile times for use as a lib crate rather than a binary target. Clean release builds are about twice as fast.

Attached are cargo build timings:
* a build from clean with all features disabled (how I use sonogram)
 
<img width="501" alt="Screen Shot 2022-10-02 at 2 19 48 PM" src="https://user-images.githubusercontent.com/8592049/193472259-98a2b9f5-b7da-4873-b50e-b0510e4f1c69.png">

* all features enabled for bin usage (I think the intended usage of sonogram)
  
<img width="470" alt="Screen Shot 2022-10-02 at 2 20 37 PM" src="https://user-images.githubusercontent.com/8592049/193472262-f4686da8-5282-4f41-8055-f0bd9aaca418.png">

 To prevent compiling clap, "build-binary" is added (https://stackoverflow.com/questions/35711044/how-can-i-specify-binary-only-dependencies) 
<img width="605" alt="Screen Shot 2022-10-02 at 2 24 09 PM" src="https://user-images.githubusercontent.com/8592049/193472424-ef59680e-a877-402b-b6fb-8124b3ec2fae.png">
