### PR TITLE
fix: to_png_in_memory dimensions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ impl Spectrogram {
         self.buf_to_img(&buf, &mut img, gradient);
 
         let mut pngbuf: Vec<u8> = Vec::new();
-        let mut encoder = png::Encoder::new(&mut pngbuf, img.len() as u32, self.height as u32);
+        let mut encoder = png::Encoder::new(&mut pngbuf, w_img as u32, h_img as u32);
         encoder.set(png::ColorType::RGBA).set(png::BitDepth::Eight);
         let mut writer = encoder.write_header()?;
         writer.write_image_data(&img)?;


### PR DESCRIPTION
The to_png_in_memory function did not work at all for me as the size of the PNG encoder did not match the img vec. This PR fixes it for me.